### PR TITLE
Remove-WindowsHelloPin

### DIFF
--- a/ThurstyUtilities.psm1
+++ b/ThurstyUtilities.psm1
@@ -21,6 +21,21 @@ function Register-DefaultPSRepository {
     }
 }
 
+function Remove-WindowsHelloPin {
+    CheckForAdmin
+    takeown /f C:\Windows\ServiceProfiles\LocalService\AppData\Local\Microsoft\Ngc /r /d y >nul
+    $acl = Get-Acl -Path "C:\Users"
+    $sysRule = New-Object System.Security.AccessControl.FileSystemAccessRule("NT AUTHORITY\SYSTEM", "FullControl", "Allow")
+    $admRule = New-Object System.Security.AccessControl.FileSystemAccessRule("BUILTIN\Administrators", "FullControl", "Allow")
+    
+    $acl.SetAccessRule($sysRule)
+    $acl.AddAccessRule($admRule)
+    
+    Get-ChildItem -Path "C:\WINDOWS\ServiceProfiles\LocalService\AppData\Local\Microsoft\Ngc" -Recurse -Force | Set-Acl ($acl)
+    
+    Remove-Item -Path "C:\WINDOWS\ServiceProfiles\LocalService\AppData\Local\Microsoft\Ngc" -Recurse -Force
+}
+
 function Set-LAPSPassword {
     [CmdletBinding()]
     param (

--- a/ThurstyUtilities.psm1
+++ b/ThurstyUtilities.psm1
@@ -22,17 +22,9 @@ function Register-DefaultPSRepository {
 }
 
 function Remove-WindowsHelloPin {
-    CheckForAdmin
-    takeown /f C:\Windows\ServiceProfiles\LocalService\AppData\Local\Microsoft\Ngc /r /d y >nul
-    $acl = Get-Acl -Path "C:\Users"
-    $sysRule = New-Object System.Security.AccessControl.FileSystemAccessRule("NT AUTHORITY\SYSTEM", "FullControl", "Allow")
-    $admRule = New-Object System.Security.AccessControl.FileSystemAccessRule("BUILTIN\Administrators", "FullControl", "Allow")
-    
-    $acl.SetAccessRule($sysRule)
-    $acl.AddAccessRule($admRule)
-    
-    Get-ChildItem -Path "C:\WINDOWS\ServiceProfiles\LocalService\AppData\Local\Microsoft\Ngc" -Recurse -Force | Set-Acl ($acl)
-    
+    Test-ElevatedPrivileges
+    takeown /f "C:\Windows\ServiceProfiles\LocalService\AppData\Local\Microsoft\Ngc" /r /d y >nul
+    icacls "C:\WINDOWS\ServiceProfiles\LocalService\AppData\Local\Microsoft\Ngc" /reset /t /c /l /q
     Remove-Item -Path "C:\WINDOWS\ServiceProfiles\LocalService\AppData\Local\Microsoft\Ngc" -Recurse -Force
 }
 


### PR DESCRIPTION
Created the "Remove-WindowsHelloPin" cmdlet, to remove pins set on devices. Passed cursory testing.